### PR TITLE
REFACTOR: pyutils upgrade, removal of duplicate methods

### DIFF
--- a/src/blitzstats/accounts.py
+++ b/src/blitzstats/accounts.py
@@ -434,6 +434,8 @@ def add_args_import(parser: ArgumentParser, config: Optional[ConfigParser] = Non
 								help='Filter by region (default is API = eu + com + asia)')
 		parser.add_argument('--sample', type=float, default=0, 
 								help='Sample size. 0 < SAMPLE < 1 : %% of stats, 1<=SAMPLE : Absolute number')
+		parser.add_argument('--force', action='store_true', default=False, 
+								help='Overwrite existing file(s) when exporting')
 
 		return True
 	except Exception as err:
@@ -1180,12 +1182,12 @@ async def fetch_wi_fetch_replays(db			: Backend,
 async def cmd_import(db: Backend, args : Namespace) -> bool:
 	"""Import accounts from other backend"""	
 	try:
-		stats 			: EventCounter 			= EventCounter('accounts import')
-		accountQ 		: Queue[BSAccount]		= Queue(ACCOUNTS_Q_MAX)
-		regions 		: set[Region]			= { Region(r) for r in args.regions }
-		import_db   	: Backend | None 		= None		
-		import_backend 	: str 					= args.import_backend
-		force 			: bool | None 			= None
+		stats 			: EventCounter 		= EventCounter('accounts import')
+		accountQ 		: Queue[BSAccount]	= Queue(ACCOUNTS_Q_MAX)
+		regions 		: set[Region]		= { Region(r) for r in args.regions }
+		import_db   	: Backend | None 	= None		
+		import_backend 	: str 				= args.import_backend
+		force 			: bool 				= args.force
 		if args.force:
 			force = True
 		

--- a/src/blitzstats/accounts.py
+++ b/src/blitzstats/accounts.py
@@ -19,7 +19,7 @@ from blitzutils			import WoTBlitzReplayJSON, WoTBlitzReplayData, \
 								WGApi, WoTinspector
 
 from .backend import Backend, OptAccountsInactive, \
-					 OptAccountsDistributed, \
+					 OptAccountsDistributed, batch_gen, \
 					 BSTableType, ACCOUNTS_Q_MAX, get_sub_type
 from .models import BSAccount, StatsTypes, BSBlitzRelease
 from .models_import import WG_Account
@@ -1504,9 +1504,13 @@ async def create_accountQ_batch(db			: Backend,
 			accounts_args : dict[str, Any] | None
 			if (accounts_args := await accounts_parse_args(db, args)) is not None:
 				accounts_args['regions'] = {region}
-				async for accounts in db.accounts_get_batch(stats_type=stats_type, 
-															batch=batch, 
-															**accounts_args):
+				# async for accounts in db.accounts_get_batch(stats_type=stats_type, 
+				# 											batch=batch, 
+				# 											**accounts_args):
+				
+				async for accounts in batch_gen(db.accounts_get(stats_type=stats_type,
+																**accounts_args), 
+												batch=batch):
 					try:
 						await accountQ.put(accounts)
 						stats.log('read', len(accounts))

--- a/src/blitzstats/accounts.py
+++ b/src/blitzstats/accounts.py
@@ -575,7 +575,7 @@ async def cmd_update_wg(db		: Backend,
 			except KeyboardInterrupt:
 				message('cancelled')
 				for workQ in workQs.values():
-					await workQ.shutdown()		
+					await workQ.finish(all=True)		
 		await stats.gather_stats(workQ_creators, merge_child=False)
 		for region in workQs.keys():
 			debug(f'waiting for idQ for {region} to complete')
@@ -834,7 +834,7 @@ async def cmd_fetch_wg(db		: Backend,
 			except KeyboardInterrupt:
 				message('cancelled')
 				for idQ in idQs.values():
-					await idQ.shutdown()		
+					await idQ.finish(all=True)		
 		await stats.gather_stats(id_creators)
 		for region in idQs.keys():
 			debug(f'waiting for idQ for {region} to complete')
@@ -935,7 +935,7 @@ async def fetch_account_info_worker(wg		: WGApi,
 		debug(f'closing accountQ: {region}')
 		await accountQ.finish()
 		debug(f'closing idQ: {region}')
-		await idQ.shutdown()		
+		await idQ.finish(all=True)		
 	return stats
 
 

--- a/src/blitzstats/backend.py
+++ b/src/blitzstats/backend.py
@@ -727,7 +727,7 @@ class Backend(ABC):
 						 batch: int = 0) -> AsyncGenerator[list[Any], None]:
 		"""Export raw objects from backend"""
 		raise NotImplementedError
-		yield [Any]			 
+		yield [Any]
 
 	#----------------------------------------
 	# accounts
@@ -787,21 +787,21 @@ class Backend(ABC):
 		yield BSAccount(id=-1)
 	
 
-	@abstractmethod
-	async def accounts_get_batch(self, 
-							stats_type 	: StatsTypes | None = None, 
-							regions		: set[Region] = Region.API_regions(), 
-							inactive 	: OptAccountsInactive = OptAccountsInactive.default(), 
-							disabled	: bool | None = False, 
-							active_since	: int = 0,
-							inactive_since	: int = 0,
-							dist 		: OptAccountsDistributed | None = None, 
-							sample 		: float = 0, 
-							cache_valid	: float = 0,
-							batch 		: int = 100) -> AsyncGenerator[list[BSAccount], None]:
-		"""Get accounts from backend"""
-		raise NotImplementedError
-		yield BSAccount(id=-1)
+	# @abstractmethod
+	# async def accounts_get_batch(self, 
+	# 						stats_type 	: StatsTypes | None = None, 
+	# 						regions		: set[Region] = Region.API_regions(), 
+	# 						inactive 	: OptAccountsInactive = OptAccountsInactive.default(), 
+	# 						disabled	: bool | None = False, 
+	# 						active_since	: int = 0,
+	# 						inactive_since	: int = 0,
+	# 						dist 		: OptAccountsDistributed | None = None, 
+	# 						sample 		: float = 0, 
+	# 						cache_valid	: float = 0,
+	# 						batch 		: int = 100) -> AsyncGenerator[list[BSAccount], None]:
+	# 	"""Get accounts from backend"""
+	# 	raise NotImplementedError
+	# 	yield BSAccount(id=-1)
 
 	@abstractmethod
 	async def accounts_count(self, 
@@ -901,7 +901,9 @@ class Backend(ABC):
 
 
 	@abstractmethod
-	async def release_insert(self, release: BSBlitzRelease) -> bool:
+	async def release_insert(self,
+							release: BSBlitzRelease, 
+							force: bool = False) -> bool:
 		"""Insert new release to the backend"""
 		raise NotImplementedError
 
@@ -912,7 +914,8 @@ class Backend(ABC):
 
 
 	@abstractmethod
-	async def release_update(self, release: BSBlitzRelease, 
+	async def release_update(self, 
+							release: BSBlitzRelease, 
 							update: dict[str, Any] | None = None, 
 							fields: list[str] | None= None) -> bool:
 		"""Update an release in the backend. Returns False 
@@ -920,12 +923,12 @@ class Backend(ABC):
 		raise NotImplementedError
 
 
-	@abstractmethod
-	async def release_replace(self, release: BSBlitzRelease, 
-								upsert: bool = False) -> bool:
-		"""Update an release in the backend. Returns False 
-			if the release was not updated"""
-		raise NotImplementedError
+	# @abstractmethod
+	# async def release_replace(self, release: BSBlitzRelease, 
+	# 							upsert: bool = False) -> bool:
+	# 	"""Update an release in the backend. Returns False 
+	# 		if the release was not updated"""
+	# 	raise NotImplementedError
 
 	
 	@abstractmethod
@@ -980,18 +983,11 @@ class Backend(ABC):
 			while True:
 				release = await releaseQ.get()
 				try:					
-					if force:
-						debug(f'Trying to upsert release={release} into {self.backend}.{self.table_releases}')
-						if await self.release_replace(release, upsert=True):
-							stats.log('releases added/updated')
-						else:
-							stats.log('releases not added')
+					debug(f'Trying to insert release={release} into {self.backend}.{self.table_releases}')
+					if await self.release_insert(release, force=force):
+						stats.log('releases added')
 					else:
-						debug(f'Trying to insert release={release} into {self.backend}.{self.table_releases}')
-						if await self.release_insert(release):
-							stats.log('releases added')
-						else:
-							stats.log('releases not added')
+						stats.log('releases not added')
 				except Exception as err:
 					debug(f'Error: {err}')
 					stats.log('errors')
@@ -1086,7 +1082,10 @@ class Backend(ABC):
 	#----------------------------------------
 
 	@abstractmethod
-	async def tank_stat_insert(self, tank_stat: WGTankStat) -> bool:
+	async def tank_stat_insert(self, 
+								tank_stat: WGTankStat, 
+								force: bool = False
+								) -> bool:
 		"""Store tank stats to the backend. Returns number of stats inserted and not inserted"""
 		raise NotImplementedError
 
@@ -1107,12 +1106,12 @@ class Backend(ABC):
 		raise NotImplementedError
 
 
-	@abstractmethod
-	async def tank_stat_replace(self, tank_stat: WGTankStat,
-								upsert: bool = False) -> bool:
-		"""Replace a tank stat in the backend. Returns False 
-			if the account was not updated"""
-		raise NotImplementedError
+	# @abstractmethod
+	# async def tank_stat_replace(self, tank_stat: WGTankStat,
+	# 							upsert: bool = False) -> bool:
+	# 	"""Replace a tank stat in the backend. Returns False 
+	# 		if the account was not updated"""
+	# 	raise NotImplementedError
 
 
 	@abstractmethod
@@ -1264,17 +1263,9 @@ class Backend(ABC):
 				read = len(tank_stats)
 				stats.log('read', read)
 				try:
-					if force:
-						# debug(f'Trying to upsert {read} tank stats into {self.backend}.{self.table_tank_stats}')
-						for tank_stat in tank_stats:
-							if await self.tank_stat_replace(tank_stat, upsert=True):
-								stats.log('added/updated')
-							else:
-								stats.log('not added')						
-					else:
-						debug(f'Trying to insert {read} tank stats into {self.backend}.{self.table_tank_stats}')
-						added, not_added = await self.tank_stats_insert(tank_stats)
-						stats.log('added', added)
+					debug(f'Trying to insert {read} tank stats into {self.backend}.{self.table_tank_stats}')
+					added, not_added = await self.tank_stats_insert(tank_stats, force=force)
+					stats.log('added', added)
 					stats.log('not added', not_added)
 				except Exception as err:
 					debug(f'Error: {err}')
@@ -1293,8 +1284,12 @@ class Backend(ABC):
 	#----------------------------------------
 
 	@abstractmethod
-	async def player_achievement_insert(self, player_achievement: WGPlayerAchievementsMaxSeries) -> bool:
-		"""Store player achievements to the backend. Returns number of stats inserted and not inserted"""
+	async def player_achievement_insert(self, 
+										player_achievement: WGPlayerAchievementsMaxSeries,
+										force: bool = False
+										) -> bool:
+		"""Store player achievements to the backend. 
+		force=True will overwrite existing item"""
 		raise NotImplementedError
 
 
@@ -1317,11 +1312,12 @@ class Backend(ABC):
 
 
 	@abstractmethod
-	async def player_achievements_get(self, release: BSBlitzRelease | None = None,
-							regions: set[Region] = Region.API_regions(), 
-							accounts: Sequence[BSAccount] | None = None,
-							since:  int = 0,
-							sample : float = 0) -> AsyncGenerator[WGPlayerAchievementsMaxSeries, None]:
+	async def player_achievements_get(self, 
+									release: BSBlitzRelease | None = None,
+									regions: set[Region] = Region.API_regions(), 
+									accounts: Sequence[BSAccount] | None = None,
+									since:  int = 0,
+									sample : float = 0) -> AsyncGenerator[WGPlayerAchievementsMaxSeries, None]:
 		"""Return player achievements from the backend"""
 		raise NotImplementedError
 		yield WGPlayerAchievementsMaxSeries()
@@ -1336,13 +1332,13 @@ class Backend(ABC):
 		raise NotImplementedError
 
 
-	@abstractmethod
-	async def player_achievement_replace(self, 
-				      					player_achievement: WGPlayerAchievementsMaxSeries,
-										upsert: bool = False) -> bool:
-		"""Replace a player achievement in the backend. Returns False 
-			if the player achievement was not replaced"""
-		raise NotImplementedError
+	# @abstractmethod
+	# async def player_achievement_replace(self, 
+	# 			      					player_achievement: WGPlayerAchievementsMaxSeries,
+	# 									upsert: bool = False) -> bool:
+	# 	"""Replace a player achievement in the backend. Returns False 
+	# 		if the player achievement was not replaced"""
+	# 	raise NotImplementedError
 	
 
 	# @abstractmethod
@@ -1396,9 +1392,9 @@ class Backend(ABC):
 				read = len(player_achievements)
 				try:
 					if force:
-						debug(f'Trying to upsert {read} player achievements into {self.backend}.{self.table_player_achievements}')
+						debug(f'Trying to insert {read} player achievements into {self.backend}.{self.table_player_achievements}')
 						for pa in player_achievements:
-							if await self.player_achievement_replace(pa, upsert=True):
+							if await self.player_achievement_insert(pa, force=True):
 								stats.log('stats added/updated')
 							else:
 								stats.log('stats not updated')
@@ -1448,6 +1444,13 @@ class Backend(ABC):
 	# Tankopedia
 	#----------------------------------------
 
+
+	@abstractmethod
+	async def tankopedia_insert(self, tank: Tank, force : bool = True) -> bool:
+		""""insert tank into Tankopedia"""
+		raise NotImplementedError
+	
+
 	@abstractmethod
 	async def tankopedia_get(self, tank_id 	: int) -> Tank | None:
 		raise NotImplementedError
@@ -1463,8 +1466,6 @@ class Backend(ABC):
 							) -> AsyncGenerator[Tank, None]:
 		raise NotImplementedError
 		yield Tank()
-
-
 
 
 	@abstractmethod
@@ -1486,10 +1487,10 @@ class Backend(ABC):
 		yield Tank()
 
 
-	@abstractmethod
-	async def tankopedia_replace(self, tank: Tank, upsert : bool = True) -> bool:
-		""""Replace tank in Tankopedia"""
-		raise NotImplementedError
+	# @abstractmethod
+	# async def tankopedia_replace(self, tank: Tank, upsert : bool = True) -> bool:
+	# 	""""Replace tank in Tankopedia"""
+	# 	raise NotImplementedError
 
 	
 	@abstractmethod
@@ -1507,31 +1508,22 @@ class Backend(ABC):
 		raise NotImplementedError
 
 
-	@abstractmethod
-	async def tankopedia_insert(self, tank: Tank) -> bool:
-		""""insert tank into Tankopedia"""
-		raise NotImplementedError
 
-
-	async def tankopedia_insert_worker(self, tankQ: Queue[Tank] , force: bool = False) -> EventCounter:
+	async def tankopedia_insert_worker(self, 
+										tankQ: Queue[Tank], 
+										force: bool = False
+										) -> EventCounter:
 		debug(f'starting, force={force}')
 		stats : EventCounter = EventCounter('tankopedia insert')
 		try:
 			while True:
 				tank : Tank = await tankQ.get()
 				try:					
-					if force:
-						debug(f'Trying to upsert tank "{tank.name}" into {self.table_uri(BSTableType.Tankopedia)}')
-						if await self.tankopedia_replace(tank, upsert=True):
-							stats.log('tanks added/updated')
-						else:
-							stats.log('tanks not added')
+					debug('Trying to ' + 'update' if force else 'insert' + f' tank "{tank}" into {self.table_uri(BSTableType.Tankopedia)}')
+					if await self.tankopedia_insert(tank, force=force):
+						stats.log('tanks added')
 					else:
-						debug(f'Trying to insert tank "{tank}" into {self.table_uri(BSTableType.Tankopedia)}')
-						if await self.tankopedia_insert(tank):
-							stats.log('tanks added')
-						else:
-							stats.log('tanks not added')
+						stats.log('tanks not added')
 				except Exception as err:
 					debug(f'Error: {err}')
 					stats.log('errors')
@@ -1571,7 +1563,9 @@ class Backend(ABC):
 
 
 	@abstractmethod
-	async def tank_string_insert(self, tank_str: WoTBlitzTankString) -> bool:
+	async def tank_string_insert(self, 
+								tank_str: WoTBlitzTankString,
+								force: bool = False) -> bool:
 		""""insert a tank string"""
 		raise NotImplementedError
 
@@ -1587,7 +1581,7 @@ class Backend(ABC):
 		yield WoTBlitzTankString()
 
 
-	@abstractmethod
-	async def tank_string_replace(self, tank_str: WoTBlitzTankString, upsert : bool = True) -> bool:
-		""""Replace tank in Tankopedia"""
-		raise NotImplementedError
+	# @abstractmethod
+	# async def tank_string_replace(self, tank_str: WoTBlitzTankString, upsert : bool = True) -> bool:
+	# 	""""Replace tank in Tankopedia"""
+	# 	raise NotImplementedError

--- a/src/blitzstats/backend.py
+++ b/src/blitzstats/backend.py
@@ -166,6 +166,16 @@ class ErrorLog(JSONExportable, ABC):
 		# json_encoders = { ObjectId: str }
 
 
+async def batch_gen(aget: AsyncGenerator[T, None], 
+				batch : int = 100) -> AsyncGenerator[list[T], None]:
+	res : list[T] = list()
+	async for item in aget:
+		res.append(item)
+		if len(res) >= batch:
+			yield res
+			res = list()
+
+
 class Backend(ABC):
 	"""Abstract class for a backend (mongo, postgres, files)"""
 

--- a/src/blitzstats/mongobackend.py
+++ b/src/blitzstats/mongobackend.py
@@ -785,11 +785,14 @@ class MongoBackend(Backend):
 ########################################################
 
 
-	async def account_insert(self, account: BSAccount) -> bool:
+	async def account_insert(self, account: BSAccount, force: bool = False) -> bool:
 		"""Store account to the backend. Returns False
 			if the account was not added"""
 		debug('starting')
-		return await self._data_insert(BSTableType.Accounts, obj=account)
+		if force: 
+			return await self._data_replace(BSTableType.Accounts, obj=account, upsert=True)
+		else:
+			return await self._data_insert(BSTableType.Accounts, obj=account)
 
 
 	async def account_get(self, account_id: int) -> BSAccount | None:
@@ -817,11 +820,11 @@ class MongoBackend(Backend):
 		return False
 
 
-	async def account_replace(self, account: BSAccount, upsert: bool = True) -> bool:
-		"""Update an account in the backend. Returns False
-			if the account was not updated"""
-		debug('starting')
-		return await self._data_replace(BSTableType.Accounts, obj=account, upsert=upsert)
+	# async def account_replace(self, account: BSAccount, upsert: bool = True) -> bool:
+	# 	"""Update an account in the backend. Returns False
+	# 		if the account was not updated"""
+	# 	debug('starting')
+	# 	return await self._data_replace(BSTableType.Accounts, obj=account, upsert=upsert)
 
 
 	async def account_delete(self, account_id: int) -> bool:

--- a/src/blitzstats/mongobackend.py
+++ b/src/blitzstats/mongobackend.py
@@ -28,7 +28,7 @@ from blitzutils import Region, Tank, WoTBlitzReplayJSON, WoTBlitzReplayData, \
 
 from .backend import Backend, OptAccountsDistributed, OptAccountsInactive, BSTableType, \
 					MAX_UPDATE_INTERVAL, WG_ACCOUNT_ID_MAX, MIN_UPDATE_INTERVAL, ErrorLog, \
-					ErrorLogType, A
+					ErrorLogType, A, batch_gen
 from .models import BSAccount, BSBlitzRelease, StatsTypes
 
 # Setup logging
@@ -918,53 +918,53 @@ class MongoBackend(Backend):
 			error(f'{err}')
 		return None
 
+	# # DEPRECIATED, use batch_gen()
+	# async def accounts_get_batch(self, 
+	# 						stats_type 	: StatsTypes | None = None, 
+	# 						regions		: set[Region] = Region.API_regions(), 
+	# 						inactive 	: OptAccountsInactive = OptAccountsInactive.default(), 
+	# 						disabled	: bool | None = False, 
+	# 						active_since	: int = 0,
+	# 						inactive_since	: int = 0,
+	# 						dist 		: OptAccountsDistributed | None = None, 
+	# 						sample 		: float = 0, 
+	# 						cache_valid	: float = 0,
+	# 						batch 		: int = 100) -> AsyncGenerator[list[BSAccount], None]:
+	# 	"""Get accounts from Mongo DB as batches 
+	# 		inactive: true = only inactive, false = not inactive, none = AUTO"""
+	# 	try:
+	# 		debug('starting')
+	# 		pipeline : list[dict[str, Any]] | None
+	# 		pipeline = await self._mk_pipeline_accounts(stats_type=stats_type, 
+	# 													regions=regions,
+	# 													inactive=inactive, 
+	# 													disabled=disabled,
+	# 													active_since=active_since,
+	# 													inactive_since=inactive_since,
+	# 													dist=dist, 
+	# 													sample=sample, 
+	# 													cache_valid=cache_valid)
+	# 		model : type[JSONExportable] = self.model_accounts
+	# 		if pipeline is None:
+	# 			raise ValueError(f'could not create get-accounts {self.table_uri(BSTableType.Accounts)} cursor')
+	# 		# message(f'accounts_get_batch(): pipeline={pipeline}')
 
-	async def accounts_get_batch(self, 
-							stats_type 	: StatsTypes | None = None, 
-							regions		: set[Region] = Region.API_regions(), 
-							inactive 	: OptAccountsInactive = OptAccountsInactive.default(), 
-							disabled	: bool | None = False, 
-							active_since	: int = 0,
-							inactive_since	: int = 0,
-							dist 		: OptAccountsDistributed | None = None, 
-							sample 		: float = 0, 
-							cache_valid	: float = 0,
-							batch 		: int = 100) -> AsyncGenerator[list[BSAccount], None]:
-		"""Get accounts from Mongo DB as batches 
-			inactive: true = only inactive, false = not inactive, none = AUTO"""
-		try:
-			debug('starting')
-			pipeline : list[dict[str, Any]] | None
-			pipeline = await self._mk_pipeline_accounts(stats_type=stats_type, 
-														regions=regions,
-														inactive=inactive, 
-														disabled=disabled,
-														active_since=active_since,
-														inactive_since=inactive_since,
-														dist=dist, 
-														sample=sample, 
-														cache_valid=cache_valid)
-			model : type[JSONExportable] = self.model_accounts
-			if pipeline is None:
-				raise ValueError(f'could not create get-accounts {self.table_uri(BSTableType.Accounts)} cursor')
-			# message(f'accounts_get_batch(): pipeline={pipeline}')
-
-			async for datas in self._datas_get_batch(BSTableType.Accounts, pipeline, 
-													batch=batch, batchSize=10000):			
-				try:
-					players : list[BSAccount] = list()
-					for obj in datas:
-						if (player := BSAccount.transform_obj(obj, in_type=model)) is not None:
-							if not disabled and inactive == OptAccountsInactive.auto \
-								and stats_type is not None and not player.update_needed(stats_type):
-								continue
-							players.append(player)
-					if len(players) > 0:
-						yield players
-				except Exception as err:
-					error(f'{err}')
-		except Exception as err:
-			error(f'Error fetching accounts from {self.table_uri(BSTableType.Accounts)}: {err}')
+	# 		async for datas in self._datas_get_batch(BSTableType.Accounts, pipeline, 
+	# 												batch=batch, batchSize=10000):			
+	# 			try:
+	# 				players : list[BSAccount] = list()
+	# 				for obj in datas:
+	# 					if (player := BSAccount.transform_obj(obj, in_type=model)) is not None:
+	# 						if not disabled and inactive == OptAccountsInactive.auto \
+	# 							and stats_type is not None and not player.update_needed(stats_type):
+	# 							continue
+	# 						players.append(player)
+	# 				if len(players) > 0:
+	# 					yield players
+	# 			except Exception as err:
+	# 				error(f'{err}')
+	# 	except Exception as err:
+	# 		error(f'Error fetching accounts from {self.table_uri(BSTableType.Accounts)}: {err}')
 
 
 
@@ -1095,7 +1095,7 @@ class MongoBackend(Backend):
 																inactive=OptAccountsInactive.both, 
 																disabled=None)) is None:
 					raise ValueError('could not create pipeline')
-				pipeline.append({ '$sort': { alias('id'): DESCENDING }} )
+				pipeline.append({ '$sort': { alias('id'): DESCENDING }})
 				async for doc in dbc.aggregate(pipeline, allowDiskUse = True):
 					if (account := BSAccount.transform_obj(doc, model)) is not None:
 						res[account.region] = account
@@ -1113,10 +1113,19 @@ class MongoBackend(Backend):
 ########################################################
 
 
-	async def player_achievement_insert(self, player_achievement: WGPlayerAchievementsMaxSeries) -> bool:
+	async def player_achievement_insert(self, 
+										player_achievement: WGPlayerAchievementsMaxSeries,
+										force: bool = False
+										) -> bool:
 		"""Insert a single player achievement"""
 		debug('starting')
-		return await self._data_insert(BSTableType.PlayerAchievements, obj=player_achievement)
+		if force:
+			return await self._data_replace(BSTableType.PlayerAchievements, 
+											obj=player_achievement, 
+											upsert=True)
+		else:
+			return await self._data_insert(BSTableType.PlayerAchievements, obj=player_achievement)
+	
 
 
 	async def player_achievement_get(self, account: BSAccount, added: int) -> WGPlayerAchievementsMaxSeries | None:
@@ -1132,15 +1141,15 @@ class MongoBackend(Backend):
 			error(f'Unknown error: {err}')
 		return None
 	
-
-	async def player_achievement_replace(self, 
-					  					player_achievement: WGPlayerAchievementsMaxSeries,
-										upsert: bool = False) -> bool:
-		"""Replace a player achievement in the backend. Returns False 
-			if the player achievement was not replaced"""
-		return await self._data_replace(BSTableType.PlayerAchievements, 
-				  						obj=player_achievement, 
-				  						upsert=upsert)
+	# DEPRECIATED
+	# async def player_achievement_replace(self, 
+	# 				  					player_achievement: WGPlayerAchievementsMaxSeries,
+	# 									upsert: bool = False) -> bool:
+	# 	"""Replace a player achievement in the backend. Returns False 
+	# 		if the player achievement was not replaced"""
+	# 	return await self._data_replace(BSTableType.PlayerAchievements, 
+	# 			  						obj=player_achievement, 
+	# 			  						upsert=upsert)
 
 
 	async def player_achievement_delete(self, account: BSAccount, added: int) -> bool:
@@ -1423,10 +1432,15 @@ class MongoBackend(Backend):
 		return None
 
 
-	async def release_insert(self, release: BSBlitzRelease) -> bool:
+	async def release_insert(self, 
+							release: BSBlitzRelease, 
+							force: bool = False) -> bool:
 		"""Insert new release to the backend"""
 		debug('starting')
-		return await self._data_insert(BSTableType.Releases, obj=release)
+		if force:
+			return await self._data_replace(BSTableType.Releases, obj=release, upsert=True)
+		else:
+			return await self._data_insert(BSTableType.Releases, obj=release)
 
 
 	async def release_update(self, release: BSBlitzRelease,
@@ -1445,14 +1459,14 @@ class MongoBackend(Backend):
 			debug(f'Error while updating release {release} into {self.table_uri(BSTableType.Releases)}: {err}')
 		return False
 
-
-	async def release_replace(self, release: BSBlitzRelease, upsert=False) -> bool:
-		"""Update an account in the backend. Returns False
-			if the account was not updated"""
-		debug('starting')
-		# return await self._data_replace(self.collection_releases, data=release,
-		# 								id=release.release, upsert=upsert)
-		return await self._data_replace(BSTableType.Releases, obj=release, upsert=upsert)
+	# DEPRECIATED
+	# async def release_replace(self, release: BSBlitzRelease, upsert=False) -> bool:
+	# 	"""Update an account in the backend. Returns False
+	# 		if the account was not updated"""
+	# 	debug('starting')
+	# 	# return await self._data_replace(self.collection_releases, data=release,
+	# 	# 								id=release.release, upsert=upsert)
+	# 	return await self._data_replace(BSTableType.Releases, obj=release, upsert=upsert)
 
 
 	async def release_delete(self, release: str) -> bool:
@@ -1633,10 +1647,15 @@ class MongoBackend(Backend):
 ########################################################
 
 
-	async def tank_stat_insert(self, tank_stat: WGTankStat) -> bool:
+	async def tank_stat_insert(self, 
+								tank_stat: WGTankStat, 
+								force: bool = False) -> bool:
 		"""Insert a single tank stat"""
 		debug('starting')
-		return await self._data_insert(BSTableType.TankStats, obj=tank_stat)
+		if force:
+			return await self._data_replace(BSTableType.TankStats, obj=tank_stat, upsert=True)
+		else:
+			return await self._data_insert(BSTableType.TankStats, obj=tank_stat)
 
 
 	async def tank_stat_get(self, account_id: int, tank_id: int,
@@ -1666,12 +1685,12 @@ class MongoBackend(Backend):
 			debug(f'Error while updating tank stat (id={tank_stat.id}) into {self.table_uri(BSTableType.TankStats)}: {err}')
 		return False
 
-		
-	async def tank_stat_replace(self, tank_stat: WGTankStat,
-								upsert: bool = False) -> bool:
-		"""Replace a tank stat in the backend. Returns False 
-			if the account was not updated"""
-		return await self._data_replace(BSTableType.TankStats, obj=tank_stat, upsert=upsert)
+	# DEPRECIATED
+	# async def tank_stat_replace(self, tank_stat: WGTankStat,
+	# 							upsert: bool = False) -> bool:
+	# 	"""Replace a tank stat in the backend. Returns False 
+	# 		if the account was not updated"""
+	# 	return await self._data_replace(BSTableType.TankStats, obj=tank_stat, upsert=upsert)
 		
 
 	async def tank_stat_delete(self, 
@@ -1689,14 +1708,15 @@ class MongoBackend(Backend):
 
 	async def tank_stats_insert(self, 
 				 				tank_stats: Sequence[WGTankStat], 
-				 				force: bool = False) -> tuple[int, int]:
+				 				force: bool = False
+								) -> tuple[int, int]:
 		"""Store tank stats to the backend. Returns the number of added and not added"""
 		debug('starting')
 		if force:
 			added		: int = 0
 			not_added	: int = len(tank_stats)
 			for ts in tank_stats:
-				if await self.tank_stat_replace(ts, upsert=True):
+				if await self.tank_stat_insert(ts, force=True):
 					added += 1
 			return added, not_added - added
 		else:	
@@ -2137,16 +2157,22 @@ class MongoBackend(Backend):
 		return -1
 
 
-	async def tankopedia_insert(self, tank: Tank) -> bool:
+	async def tankopedia_insert(self,
+								tank: Tank, 
+								force: bool = False
+								) -> bool:
 		""""insert tank into Tankopedia"""
 		debug('starting')
-		return await self._data_insert(BSTableType.Tankopedia, obj=tank)
+		if force:
+			return await self._data_replace(BSTableType.Tankopedia, obj=tank, upsert=True)
+		else:
+			return await self._data_insert(BSTableType.Tankopedia, obj=tank)
 
-
-	async def tankopedia_replace(self, tank: Tank, upsert : bool = True) -> bool:
-		""""Replace tank in Tankopedia"""
-		debug('starting')
-		return await self._data_replace(BSTableType.Tankopedia, obj=tank, upsert=upsert)
+	# DEPRECIATED
+	# async def tankopedia_replace(self, tank: Tank, upsert : bool = True) -> bool:
+	# 	""""Replace tank in Tankopedia"""
+	# 	debug('starting')
+	# 	return await self._data_replace(BSTableType.Tankopedia, obj=tank, upsert=upsert)
 
 
 	async def tankopedia_update(self, tank: Tank,
@@ -2187,9 +2213,14 @@ class MongoBackend(Backend):
 	########################################################
 
 
-	async def tank_string_insert(self, tank_str: WoTBlitzTankString) -> bool:
+	async def tank_string_insert(self, 
+								tank_str: WoTBlitzTankString, 
+								force: bool = True) -> bool:
 		""""insert a tank string"""
-		return await self._data_insert(BSTableType.TankStrings, tank_str)
+		if force:
+			return await self._data_replace(BSTableType.TankStrings, obj=tank_str, upsert=True)
+		else:
+			return await self._data_insert(BSTableType.TankStrings, tank_str)
 
 
 	async def tank_string_get(self, code: str) -> WoTBlitzTankString | None:
@@ -2218,10 +2249,10 @@ class MongoBackend(Backend):
 		except Exception as err:
 			error(f"Could't get tank strings for search string: {search}: {err}")
 
-
-	async def tank_string_replace(self, tank_str: WoTBlitzTankString, upsert : bool = True) -> bool:
-		""""Replace tank in Tankopedia"""
-		return await self._data_replace(BSTableType.TankStrings, obj=tank_str, upsert=upsert)
+	# DEPRECIATED
+	# async def tank_string_replace(self, tank_str: WoTBlitzTankString, upsert : bool = True) -> bool:
+	# 	""""Replace tank in Tankopedia"""
+	# 	return await self._data_replace(BSTableType.TankStrings, obj=tank_str, upsert=upsert)
 
 
 	########################################################

--- a/src/blitzstats/tank_stats.py
+++ b/src/blitzstats/tank_stats.py
@@ -807,13 +807,13 @@ async def fetch_backend_worker(db: Backend,
 						# 		stats.log('accounts marked inactive')
 						# 	account.inactive = True
 						
-					await db.account_replace(account=account, upsert=True)
+					await db.account_insert(account=account, force=True)
 			except Exception as err:
 				error(f'{err}')
 			finally:
 				stats.log('tank stats added', added)
 				stats.log('old tank stats found', not_added)
-				debug(f'{added} tank stats added, {not_added} old tank stats found')				
+				debug(f'{added} tank stats added, {not_added} old tank stats found')
 				statsQ.task_done()
 	except CancelledError as err:
 		debug(f'Cancelled')	

--- a/src/blitzstats/tankopedia.py
+++ b/src/blitzstats/tankopedia.py
@@ -379,29 +379,19 @@ async def cmd_update(db: Backend, args : Namespace) -> bool:
 					continue
 				# print(f'tank_id={tank.tank_id}, name={tank.name}, tier={tank.tier}')
 				try:
-					if force:
-						if await db.tankopedia_replace(tank=tank):
-							verbose(f'Replaced: tank_id={tank.tank_id} {tank.name}')
-							stats.log('tanks updated')
-					else:
-						if await db.tankopedia_get(tank.tank_id) is None:
-							if await db.tankopedia_insert(tank=tank):
-								verbose(f'Added: tank_id={tank.tank_id} {tank.name}')
-								stats.log('tanks added')
+					if await db.tankopedia_insert(tank=tank, force=force):
+						verbose(f'Added: tank_id={tank.tank_id} {tank.name}')
+						stats.log('tanks added')
 				except Exception as err:
 					error(f'Unexpected error ({tank.tank_id}): {err}')
 
 			tank_strs : list[WoTBlitzTankString] | None
 			if (tank_strs := WoTBlitzTankString.from_tankopedia(tankopedia)) is not None:
 				for tank_str in tank_strs:
-					if force:
-						if await db.tank_string_replace(tank_str):
-							stats.log('tank strings updated')
+					if await db.tank_string_insert(tank_str, force=force):
+						stats.log('tank strings added')
 					else:
-						if await db.tank_string_get(tank_str.code) is None:
-							if await db.tank_string_insert(tank_str):
-								stats.log('tank strings added')				
-					
+						stats.log('tank strings not added')
 			
 	except Exception as err:	
 		error(f'Failed to update tankopedia from {filename}: {err}')


### PR DESCRIPTION
* `Backend()`: Replace `_replace()` methods with `_insert(force=True)` to reduce number
* `IterableQueue.finish(all=True)` replacing  `shutdown()`
* use `batch_gen()` instead of separate methods to create batches