### PR TITLE
FIX release cut-off issues

### DIFF
--- a/src/blitzstats/accounts.py
+++ b/src/blitzstats/accounts.py
@@ -1660,7 +1660,7 @@ def read_args_accounts(accounts: list[str]) -> list[BSAccount] | None:
 
 
 async def accounts_parse_args(db: Backend, 
-			      				args : Namespace,
+							  args : Namespace,
 							 ) -> dict[str, Any] | None:
 	"""parse accounts args"""
 	debug('starting')
@@ -1704,7 +1704,7 @@ async def accounts_parse_args(db: Backend,
 			debug('could not read --distributed')
 		
 		days : int
-		today : datetime = datetime.today()
+		today : datetime = datetime.utcnow()
 		start : datetime
 		try:
 			if ( rel := await db.release_get(args.inactive_since)) is not None:
@@ -1719,7 +1719,9 @@ async def accounts_parse_args(db: Backend,
 		
 		try:
 			if ( rel := await db.release_get(args.active_since)) is not None:
+				# debug(f'active_since={rel}')
 				if (prev := await db.release_get_previous(rel)) is not None:
+					#debug(f'active_since: prev={prev}')
 					res['active_since'] = prev.cut_off
 			else:
 				days = int(args.active_since)

--- a/src/blitzstats/models.py
+++ b/src/blitzstats/models.py
@@ -201,9 +201,10 @@ class BSBlitzRelease(WGBlitzRelease):
 
 	@validator('cut_off')
 	def validate_cut_off(cls, v: int) -> int:
-		ROUND_TO : int = 10*60
+		# ROUND_TO : int = 10*60
 		if v >= 0:
-			return ceil(v / ROUND_TO) * ROUND_TO
+			# return ceil(v / ROUND_TO) * ROUND_TO
+			return v
 		raise ValueError('cut_off has to be >= 0')
 
 


### PR DESCRIPTION
* Use `datetime.utctime()` not `today()`
* `BSBlitzRelease()`: remove rounding of cut-off