### PR TITLE
version: 0.9.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blitz-stats"
-version = "0.9.18"
+version = "0.9.19"
 authors = [ 
 	{ name="Jylpah", email="jylpah@gmail.com"} 
 	]

--- a/src/blitzstats/models.py
+++ b/src/blitzstats/models.py
@@ -1,6 +1,5 @@
 import logging
 from enum import StrEnum
-from sys import maxsize
 from time import time
 import json
 from typing import Optional, ClassVar, Any
@@ -159,16 +158,24 @@ class BSAccount(Account):
     def is_inactive(self, stats_type: StatsTypes | None = None) -> bool:
         """Check if account is active"""
         stats_updated: int | None
-        if stats_type is None or (stats_updated := getattr(self, stats_type.value)) is None:
+        if (
+            stats_type is None
+            or (stats_updated := getattr(self, stats_type.value)) is None
+        ):
             stats_updated = epoch_now()
-        return stats_updated - self.last_battle_time > self._min_inactivity_days * 24 * 3600
+        return (
+            stats_updated - self.last_battle_time
+            > self._min_inactivity_days * 24 * 3600
+        )
 
     def update_needed(self, stats_type: StatsTypes) -> bool:
         """Check whether the account needs an update"""
         stats_updated: int | None
         if (stats_updated := getattr(self, stats_type.value)) is None:
             stats_updated = 0
-        return (epoch_now() - stats_updated) > min(MAX_UPDATE_INTERVAL, (stats_updated - self.last_battle_time) / 3)
+        return (epoch_now() - stats_updated) > min(
+            MAX_UPDATE_INTERVAL, (stats_updated - self.last_battle_time) / 3
+        )
 
     def update(self, update: WGAccountInfo) -> bool:
         """Update BSAccount() from WGACcountInfo i.e. from WG API"""
@@ -214,7 +221,8 @@ BSAccount.register_transformation(Account, BSAccount.transform_Account)
 
 
 class BSBlitzRelease(WGBlitzRelease):
-    cut_off: int = Field(default=maxsize)
+    _max_epoch: int = 2 ^ 63 - 1  # MAX_INT64 (signed)
+    cut_off: int = Field(default=_max_epoch)
 
     class Config:
         allow_mutation = True
@@ -224,7 +232,7 @@ class BSBlitzRelease(WGBlitzRelease):
     @validator("cut_off", pre=True)
     def check_cut_off_now(cls, v):
         if v is None:
-            return maxsize
+            return cls._max_epoch
         elif isinstance(v, str) and v == "now":
             return epoch_now()
         else:
@@ -296,11 +304,19 @@ class BSBlitzReplay(WoTBlitzReplaySummary):
                 ("battle_start_timestamp", DESCENDING),
             ]
         )
-        indexes.append([("room_type", ASCENDING), ("vehicle_tier", ASCENDING), ("battle_start_timestamp", DESCENDING)])
+        indexes.append(
+            [
+                ("room_type", ASCENDING),
+                ("vehicle_tier", ASCENDING),
+                ("battle_start_timestamp", DESCENDING),
+            ]
+        )
         return indexes
 
     @classmethod
-    def transform_WoTBlitzReplayData(cls, in_obj: WoTBlitzReplayData) -> Optional["BSBlitzReplay"]:
+    def transform_WoTBlitzReplayData(
+        cls, in_obj: WoTBlitzReplayData
+    ) -> Optional["BSBlitzReplay"]:
         res: BSBlitzReplay | None = None
         try:
             if (res := BSBlitzReplay.parse_obj(in_obj.summary.dict())) is not None:
@@ -313,14 +329,20 @@ class BSBlitzReplay(WoTBlitzReplaySummary):
         return res
 
     @classmethod
-    def transform_WoTBlitzReplayJSON(cls, in_obj: WoTBlitzReplayJSON) -> Optional["BSBlitzReplay"]:
+    def transform_WoTBlitzReplayJSON(
+        cls, in_obj: WoTBlitzReplayJSON
+    ) -> Optional["BSBlitzReplay"]:
         if (replay_data := WoTBlitzReplayData.transform(in_obj)) is not None:
             return cls.transform_WoTBlitzReplayData(replay_data)
         return None
 
 
-BSBlitzReplay.register_transformation(WoTBlitzReplayData, BSBlitzReplay.transform_WoTBlitzReplayData)
-BSBlitzReplay.register_transformation(WoTBlitzReplayJSON, BSBlitzReplay.transform_WoTBlitzReplayJSON)
+BSBlitzReplay.register_transformation(
+    WoTBlitzReplayData, BSBlitzReplay.transform_WoTBlitzReplayData
+)
+BSBlitzReplay.register_transformation(
+    WoTBlitzReplayJSON, BSBlitzReplay.transform_WoTBlitzReplayJSON
+)
 
 
 # fmt: off

--- a/src/blitzstats/models.py
+++ b/src/blitzstats/models.py
@@ -221,8 +221,10 @@ BSAccount.register_transformation(Account, BSAccount.transform_Account)
 
 
 class BSBlitzRelease(WGBlitzRelease):
-    _max_epoch: int = 2 ^ 63 - 1  # MAX_INT64 (signed)
+    _max_epoch: int = 2**63 - 1  # MAX_INT64 (signed)
     cut_off: int = Field(default=_max_epoch)
+
+    _exclude_defaults = False
 
     class Config:
         allow_mutation = True

--- a/src/blitzstats/releases.py
+++ b/src/blitzstats/releases.py
@@ -87,10 +87,18 @@ def add_args_add(parser: ArgumentParser, config: Optional[ConfigParser] = None) 
             "release", type=str, default=None, metavar="RELEASE", help="RELEASE to add"
         )
         parser.add_argument(
-            "--launch", type=str, default=None, help="release launch date"
+            "--launch",
+            type=str,
+            default=None,
+            metavar="DATE",
+            help="release launch date",
         )
         parser.add_argument(
-            "--cut-off", type=str, default=None, help="release cut-off time"
+            "--cut-off",
+            type=str,
+            default=None,
+            metavar="EPOCH",
+            help="release cut-off time",
         )
         parser.add_argument(
             "--round-cut-off",
@@ -115,10 +123,18 @@ def add_args_edit(
             "release", type=str, metavar="RELEASE", help="RELEASE to edit"
         )
         parser.add_argument(
-            "--cut-off", type=str, default=None, help="new release cut-off time"
+            "--cut-off",
+            type=str,
+            default=None,
+            metavar="EPOCH",
+            help="new release cut-off time",
         )
         parser.add_argument(
-            "--launch", type=str, default=None, help="new release launch date"
+            "--launch",
+            type=str,
+            default=None,
+            metavar="DATE",
+            help="new release launch date",
         )
         parser.add_argument(
             "--round-cut-off",


### PR DESCRIPTION
* Store `BSBlitzRelease.cut_off` to the backend
* `bs releases add | edit`: Better help texts