### PR TITLE
Version 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blitz-stats"
-version = "1.0.0a6"
+version = "1.0.1"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Tool to fetch, manage and export stats for Wargaming's World of Tanks Blitz game "
 readme = "README.md"

--- a/src/blitzstats/bs.py
+++ b/src/blitzstats/bs.py
@@ -21,7 +21,7 @@ from os import linesep
 from os.path import isfile, dirname, realpath, expanduser
 from asyncio import run
 
-# from importlib.metadata import version
+from importlib.metadata import version, PackageNotFoundError
 # sys.path.insert(0, dirname(dirname(realpath(__file__))))
 
 from blitzstats.backend import Backend
@@ -100,10 +100,16 @@ async def main() -> int:
     if CONFIG_FILE is None:
         error("config file not found in: " + ", ".join(CONFIG_FILES))
 
+    version_str: str = "--dev--"
+    try:
+        version_str = version("blitz-stats")
+    except PackageNotFoundError:
+        pass
+
     parser = ArgumentParser(
         description="Fetch and manage WoT Blitz stats",
         add_help=False,
-        # epilog=f"Version {version('blitzstats')}",
+        epilog=f"Version {version_str}",
     )
     arggroup_verbosity = parser.add_mutually_exclusive_group()
     arggroup_verbosity.add_argument(

--- a/src/blitzstats/bs.py
+++ b/src/blitzstats/bs.py
@@ -16,7 +16,7 @@ except (ImportError, ModuleNotFoundError):
 from configparser import ConfigParser
 import logging
 from argparse import ArgumentParser
-from sys import stdout
+from sys import stdout, stderr, exit
 from os import linesep
 from os.path import isfile, dirname, realpath, expanduser
 from asyncio import run
@@ -33,6 +33,13 @@ from blitzstats import tank_stats
 from blitzstats import player_achievements
 from blitzstats import setup
 from blitzstats import tankopedia
+
+
+class BSParser(ArgumentParser):
+    def error(self, message):
+        stderr.write("error: %s\n" % message)
+        self.print_help()
+        exit(2)
 
 
 # logging.getLogger("asyncio").setLevel(logging.DEBUG)
@@ -100,13 +107,13 @@ async def main() -> int:
     if CONFIG_FILE is None:
         error("config file not found in: " + ", ".join(CONFIG_FILES))
 
-    version_str: str = "--dev--"
+    version_str: str = "[dev]"
     try:
         version_str = version("blitz-stats")
     except PackageNotFoundError:
         pass
 
-    parser = ArgumentParser(
+    parser = BSParser(
         description="Fetch and manage WoT Blitz stats",
         add_help=False,
         epilog=f"Version {version_str}",


### PR DESCRIPTION
- FIX error message when run without commands: `bs --help` now shows ... help
- Print version number with --help